### PR TITLE
implemented type 5 - foreign SEPA

### DIFF
--- a/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
+++ b/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
@@ -84,7 +84,7 @@ class CustomerCreditTransfer extends AbstractMessage
     protected function buildDom(\DOMDocument $doc)
     {
         $transactionCount = 0;
-        $transactionSum = new Money\CHF(0);
+        $transactionSum = new Money\Mixed(0);
         foreach ($this->payments as $payment) {
             $transactionCount += $payment->getTransactionCount();
             $transactionSum = $transactionSum->plus($payment->getTransactionSum());

--- a/src/Z38/SwissPayment/Money/Mixed.php
+++ b/src/Z38/SwissPayment/Money/Mixed.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Z38\SwissPayment\Money;
+
+/**
+ * Sum of money in Mixed currencies
+ */
+class Mixed extends Money
+{
+    /**
+     * {@inheritdoc}
+     */
+    final public function getCurrency()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final protected function getDecimals()
+    {
+        return 2;
+    }
+
+    /**
+     * Returns the sum of this and an other amount of money
+     *
+     * @param Money $addend The addend
+     *
+     * @return Money The sum
+     */
+    public function plus(Money $addend)
+    {
+        return new static($this->cents + $addend->cents);
+    }
+
+    /**
+     * Returns the subtraction of this and an other amount of money
+     *
+     * @param Money $subtrahend The subtrahend
+     *
+     * @return Money The difference
+     */
+    public function minus(Money $subtrahend)
+    {
+        return new static($this->cents - $subtrahend->cents);
+    }
+
+    /**
+     * Compares this instance with an other instance.
+     *
+     * @param Money $b The instance to which this instance is to be compared.
+     *
+     * @return int -1, 0 or 1 as this instance is less than, equal to, or greater than $b
+     */
+    public function compareTo(Money $b)
+    {
+        if ($this->getAmount() < $b->getAmount()) {
+            return -1;
+        } elseif ($this->getAmount() == $b->getAmount()) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * Returns true if the argument contains the same amount and the same currency.
+     *
+     * @param object $obj
+     *
+     * @return bool True if $obj is equal to this instance
+     */
+    public function equals($obj)
+    {
+        if (!($obj instanceof Money)) {
+            return false;
+        }
+
+        return ($this->getAmount() == $obj->getAmount());
+    }
+}

--- a/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
+++ b/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
@@ -99,11 +99,11 @@ class PaymentInformation
     /**
      * Gets the sum of transactions
      *
-     * @return Money\CHF Sum of transactions
+     * @return Money\Mixed Sum of transactions
      */
     public function getTransactionSum()
     {
-        $sum = new Money\CHF(0);
+        $sum = new Money\Mixed(0);
 
         foreach ($this->transactions as $transaction) {
             $sum = $sum->plus($transaction->getAmount());

--- a/src/Z38/SwissPayment/TransactionInformation/CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/CreditTransfer.php
@@ -97,10 +97,11 @@ abstract class CreditTransfer
      *
      * @param \DOMDocument $doc
      * @param string|null  $localInstrument Local Instrument
+     * @param string|null  $serviceLevel
      *
      * @return \DOMNode The built DOM node
      */
-    protected function buildHeader(\DOMDocument $doc, $localInstrument)
+    protected function buildHeader(\DOMDocument $doc, $localInstrument, $serviceLevel = null)
     {
         $root = $doc->createElement('CdtTrfTxInf');
 
@@ -113,6 +114,12 @@ abstract class CreditTransfer
             $paymentType = $doc->createElement('PmtTpInf');
             $localInstrumentNode = $doc->createElement('LclInstrm');
             $localInstrumentNode->appendChild($doc->createElement('Prtry', $localInstrument));
+            $paymentType->appendChild($localInstrumentNode);
+            $root->appendChild($paymentType);
+        } elseif (!empty($serviceLevel)) {
+            $paymentType = $doc->createElement('PmtTpInf');
+            $localInstrumentNode = $doc->createElement('SvcLvl');
+            $localInstrumentNode->appendChild($doc->createElement('Cd', $serviceLevel));
             $paymentType->appendChild($localInstrumentNode);
             $root->appendChild($paymentType);
         }

--- a/src/Z38/SwissPayment/TransactionInformation/ForeignSEPACreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ForeignSEPACreditTransfer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Z38\SwissPayment\TransactionInformation;
+
+use Z38\SwissPayment\BIC;
+use Z38\SwissPayment\IBAN;
+use Z38\SwissPayment\PostalAddress;
+use Z38\SwissPayment\PostalAccount;
+use Z38\SwissPayment\Money;
+
+/**
+ * ForeignSEPACreditTransfer contains all the information about a foreign SEPA (type 5) transaction.
+ */
+class ForeignSEPACreditTransfer extends CreditTransfer
+{
+    /**
+     * @var IBAN
+     */
+    protected $creditorIBAN;
+
+    /**
+     * @var BIC
+     */
+    protected $creditorAgentBIC;
+
+    /**
+     * @var PostalAccount
+     */
+    protected $creditorAgentPostal;
+
+    /**
+     * {@inheritdoc}
+     * @param IBAN          $creditorIBAN        IBAN of the creditor
+     * @param BIC           $creditorAgentBIC    BIC of the creditor's financial institution
+     */
+    public function __construct($instructionId, $endToEndId, Money\EUR $amount, $creditorName, PostalAddress $creditorAddress, IBAN $creditorIBAN, BIC $creditorAgentBIC)
+    {
+        parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
+
+        $this->creditorIBAN = $creditorIBAN;
+        $this->creditorAgentBIC = $creditorAgentBIC;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asDom(\DOMDocument $doc)
+    {
+        $root = $this->buildHeader($doc, null, 'SEPA');
+
+        $creditorAgent = $doc->createElement('CdtrAgt');
+
+        $creditorAgent->appendChild($this->creditorAgentBIC->asDom($doc));
+
+        /*$creditorAgentId = $doc->createElement('FinInstnId');
+        $creditorAgentId->appendChild($doc->createElement('BIC', $this->creditorAgentBIC));
+        $creditorAgentIdOther = $doc->createElement('Othr');
+        $creditorAgentIdOther->appendChild($doc->createElement('Id', $this->creditorAgentPostal->format()));
+        $creditorAgentId->appendChild($creditorAgentIdOther);
+        $creditorAgent->appendChild($creditorAgentId);*/
+        $root->appendChild($creditorAgent);
+
+        $root->appendChild($this->buildCreditor($doc));
+
+        $creditorAccount = $doc->createElement('CdtrAcct');
+        $creditorAccountId = $doc->createElement('Id');
+        $creditorAccountId->appendChild($doc->createElement('IBAN', $this->creditorIBAN->normalize()));
+        $creditorAccount->appendChild($creditorAccountId);
+        $root->appendChild($creditorAccount);
+
+        if ($this->hasRemittanceInformation()) {
+            $root->appendChild($this->buildRemittanceInformation($doc));
+        }
+
+        return $root;
+    }
+}

--- a/src/Z38/SwissPayment/TransactionInformation/ForeignSEPACreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ForeignSEPACreditTransfer.php
@@ -51,13 +51,6 @@ class ForeignSEPACreditTransfer extends CreditTransfer
         $creditorAgent = $doc->createElement('CdtrAgt');
 
         $creditorAgent->appendChild($this->creditorAgentBIC->asDom($doc));
-
-        /*$creditorAgentId = $doc->createElement('FinInstnId');
-        $creditorAgentId->appendChild($doc->createElement('BIC', $this->creditorAgentBIC));
-        $creditorAgentIdOther = $doc->createElement('Othr');
-        $creditorAgentIdOther->appendChild($doc->createElement('Id', $this->creditorAgentPostal->format()));
-        $creditorAgentId->appendChild($creditorAgentIdOther);
-        $creditorAgent->appendChild($creditorAgentId);*/
         $root->appendChild($creditorAgent);
 
         $root->appendChild($this->buildCreditor($doc));


### PR DESCRIPTION
I had to implement a Mixed-Currency because the "CtrlSum" in the "GrpHdr" does not care about currencies (https://gist.github.com/toooni/200db56e932a16210e6a#file-pain_001_beispiel_1-xml-L138) - It's just a sum of all amounts.
I didn't know what to do about the mixed currencies. Maybe you have a better idea?

As soon as this PR will be merged. I will start implement type 6.
