### PR TITLE
Add EUR support to IS1 & IS2

### DIFF
--- a/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
@@ -22,9 +22,18 @@ class IS1CreditTransfer extends CreditTransfer
      * {@inheritdoc}
      *
      * @param PostalAccount $creditorAccount Postal account of the creditor
+     *
+     * @throws \InvalidArgumentException. An InvalidArgumentException is thrown if amount is not EUR or CHF
      */
-    public function __construct($instructionId, $endToEndId, Money\CHF $amount, $creditorName, PostalAddressInterface $creditorAddress, PostalAccount $creditorAccount)
+    public function __construct($instructionId, $endToEndId, Money\Money $amount, $creditorName, PostalAddressInterface $creditorAddress, PostalAccount $creditorAccount)
     {
+        if (false === $amount instanceof Money\EUR && false === $amount instanceof Money\CHF) {
+            throw new \InvalidArgumentException(sprintf(
+                'Amount must be an instance of Z38\SwissPayment\Money\EUR or Z38\SwissPayment\Money\CHF. Instance of %s given.',
+                get_class($amount)
+            ));
+        }
+
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         $this->creditorAccount = $creditorAccount;

--- a/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
@@ -35,9 +35,18 @@ class IS2CreditTransfer extends CreditTransfer
      * @param IBAN          $creditorIBAN        IBAN of the creditor
      * @param string        $creditorAgentName   Name of the creditor's financial institution
      * @param PostalAccount $creditorAgentPostal Postal account of the creditor's financial institution
+     *
+     * @throws \InvalidArgumentException. An InvalidArgumentException is thrown if amount is not EUR or CHF
      */
-    public function __construct($instructionId, $endToEndId, Money\CHF $amount, $creditorName, PostalAddressInterface $creditorAddress, IBAN $creditorIBAN, $creditorAgentName, PostalAccount $creditorAgentPostal)
+    public function __construct($instructionId, $endToEndId, Money\Money $amount, $creditorName, PostalAddressInterface $creditorAddress, IBAN $creditorIBAN, $creditorAgentName, PostalAccount $creditorAgentPostal)
     {
+        if (false === $amount instanceof Money\EUR && false === $amount instanceof Money\CHF) {
+            throw new \InvalidArgumentException(sprintf(
+                'Amount must be an instance of Z38\SwissPayment\Money\EUR or Z38\SwissPayment\Money\CHF. Instance of %s given.',
+                get_class($amount)
+            ));
+        }
+
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         $this->creditorIBAN = $creditorIBAN;

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/IS1CreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/IS1CreditTransferTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Z38\SwissPayment\Tests;
+
+use Z38\SwissPayment\IBAN;
+use Z38\SwissPayment\Money;
+use Z38\SwissPayment\StructuredPostalAddress;
+use Z38\SwissPayment\PostalAccount;
+use Z38\SwissPayment\TransactionInformation\IS1CreditTransfer;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\TransactionInformation\IS1CreditTransfer
+ */
+class IS1CreditTransferTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidAmount()
+    {
+        $transfer = new IS1CreditTransfer(
+            'id000',
+            'name',
+            new Money\USD(100),
+            'name',
+            new StructuredPostalAddress('foo', '99', '9999', 'bar'),
+            new PostalAccount('10-2424-4')
+        );
+    }
+}

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/IS2CreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/IS2CreditTransferTest.php
@@ -2,15 +2,16 @@
 
 namespace Z38\SwissPayment\Tests;
 
+use Z38\SwissPayment\IBAN;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\StructuredPostalAddress;
 use Z38\SwissPayment\PostalAccount;
-use Z38\SwissPayment\TransactionInformation\IS1CreditTransfer;
+use Z38\SwissPayment\TransactionInformation\IS2CreditTransfer;
 
 /**
- * @coversDefaultClass \Z38\SwissPayment\TransactionInformation\IS1CreditTransfer
+ * @coversDefaultClass \Z38\SwissPayment\TransactionInformation\IS2CreditTransfer
  */
-class IS1CreditTransferTest extends TestCase
+class IS2CreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
@@ -18,12 +19,14 @@ class IS1CreditTransferTest extends TestCase
      */
     public function testInvalidAmount()
     {
-        $transfer = new IS1CreditTransfer(
+        $transfer = new IS2CreditTransfer(
             'id000',
             'name',
             new Money\USD(100),
-            'name',
+            'creditor name',
             new StructuredPostalAddress('foo', '99', '9999', 'bar'),
+            new Iban('AZ21 NABZ 0000 0000 1370 1000 1944'),
+            'name',
             new PostalAccount('10-2424-4')
         );
     }


### PR DESCRIPTION
It seems IS1 and IS2 should accept either CHF or EUR as currency (see p.14 [here](http://www.six-interbank-clearing.com/dam/downloads/en/standardization/iso/swiss-recommendations/implementation_guidelines_ct.pdf))
