### PR TITLE
Fix Bank Credit Transfer

### DIFF
--- a/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
@@ -31,9 +31,20 @@ class BankCreditTransfer extends CreditTransfer
      *
      * @param IBAN   $creditorIBAN  IBAN of the creditor
      * @param BC|BIC $creditorAgent BC or BIC of the creditor's financial institution
+     *
+     * @throws \InvalidArgumentException.
+     *     An InvalidArgumentException is thrown if amount is not EUR or CHF
+     *     or if creditorAgent is not BC or BIC
      */
-    public function __construct($instructionId, $endToEndId, Money\CHF $amount, $creditorName, PostalAddressInterface $creditorAddress, IBAN $creditorIBAN, FinancialInstitutionInterface $creditorAgent)
+    public function __construct($instructionId, $endToEndId, Money\Money $amount, $creditorName, PostalAddressInterface $creditorAddress, IBAN $creditorIBAN, FinancialInstitutionInterface $creditorAgent)
     {
+        if (false === $amount instanceof Money\EUR && false === $amount instanceof Money\CHF) {
+            throw new \InvalidArgumentException(sprintf(
+                'Amount must be an instance of Z38\SwissPayment\Money\EUR or Z38\SwissPayment\Money\CHF. Instance of %s given.',
+                get_class($amount)
+            ));
+        }
+
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         if (!$creditorAgent instanceof BC && !$creditorAgent instanceof BIC) {

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/BankCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/BankCreditTransferTest.php
@@ -6,6 +6,7 @@ use Z38\SwissPayment\IBAN;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\StructuredPostalAddress;
 use Z38\SwissPayment\TransactionInformation\BankCreditTransfer;
+use Z38\SwissPayment\BIC;
 
 /**
  * @coversDefaultClass \Z38\SwissPayment\TransactionInformation\BankCreditTransfer
@@ -28,6 +29,23 @@ class BankCreditTransferTest extends TestCase
             new StructuredPostalAddress('foo', '99', '9999', 'bar'),
             new IBAN('CH31 8123 9000 0012 4568 9'),
             $creditorAgent
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidAmount()
+    {
+        $transfer = new BankCreditTransfer(
+            'id000',
+            'name',
+            new Money\USD(100),
+            'name',
+            new StructuredPostalAddress('foo', '99', '9999', 'bar'),
+            new IBAN('CH31 8123 9000 0012 4568 9'),
+            new BIC('PSETPD2SZZZ')
         );
     }
 }


### PR DESCRIPTION
It seems Bank Credit Transfer should allow EUR and CHF (see [here](http://www.six-interbank-clearing.com/dam/downloads/en/standardization/iso/swiss-recommendations/implementation_guidelines_ct.pdf), p. 14).
