### PR TITLE
Add support for transaction purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SwissPayment Changelog
 
+## 0.X.X (2017-XX-XX)
+
+  * Added support for transaction purposes.
+
 ## 0.4.1 (2016-08-31)
 
   * Write IID without leading zeroes (for legacy systems)

--- a/src/Z38/SwissPayment/PaymentInformation/CategoryPurposeCode.php
+++ b/src/Z38/SwissPayment/PaymentInformation/CategoryPurposeCode.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Z38\SwissPayment\PaymentInformation;
+
+use DOMDocument;
+use InvalidArgumentException;
+
+/**
+ * CategoryPurposeCode contains a category purpose code from the External Code Sets
+ */
+class CategoryPurposeCode
+{
+    /**
+     * @var string
+     */
+    protected $code;
+
+    /**
+     * Constructor
+     *
+     * @param string $code
+     *
+     * @throws InvalidArgumentException When the code is not valid
+     */
+    public function __construct($code)
+    {
+        $code = (string) $code;
+        if (!preg_match('/^[A-Z]{4}$/', $code)) {
+            throw new InvalidArgumentException('The category purpose code is not valid.');
+        }
+
+        $this->code = $code;
+    }
+
+    /**
+     * Returns a XML representation of this purpose
+     *
+     * @param \DOMDocument $doc
+     *
+     * @return \DOMElement The built DOM element
+     */
+    public function asDom(DOMDocument $doc)
+    {
+        return $doc->createElement('Cd', $this->code);
+    }
+}

--- a/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
@@ -71,9 +71,9 @@ class BankCreditTransfer extends CreditTransfer
         $creditorAccount->appendChild($this->creditorIBAN->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        if ($this->hasRemittanceInformation()) {
-            $root->appendChild($this->buildRemittanceInformation($doc));
-        }
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }

--- a/src/Z38/SwissPayment/TransactionInformation/ForeignCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ForeignCreditTransfer.php
@@ -82,9 +82,9 @@ class ForeignCreditTransfer extends CreditTransfer
         $creditorAccount->appendChild($this->creditorAccount->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        if ($this->hasRemittanceInformation()) {
-            $root->appendChild($this->buildRemittanceInformation($doc));
-        }
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }

--- a/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
@@ -38,6 +38,7 @@ class IS1CreditTransfer extends CreditTransfer
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         $this->creditorAccount = $creditorAccount;
+        $this->localInstrument = 'CH02';
     }
 
     /**
@@ -45,7 +46,7 @@ class IS1CreditTransfer extends CreditTransfer
      */
     public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
     {
-        $root = $this->buildHeader($doc, $paymentInformation, 'CH02');
+        $root = $this->buildHeader($doc, $paymentInformation);
 
         $root->appendChild($this->buildCreditor($doc));
 
@@ -53,9 +54,9 @@ class IS1CreditTransfer extends CreditTransfer
         $creditorAccount->appendChild($this->creditorAccount->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        if ($this->hasRemittanceInformation()) {
-            $root->appendChild($this->buildRemittanceInformation($doc));
-        }
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }

--- a/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
@@ -53,6 +53,7 @@ class IS2CreditTransfer extends CreditTransfer
         $this->creditorIBAN = $creditorIBAN;
         $this->creditorAgentName = (string) $creditorAgentName;
         $this->creditorAgentPostal = $creditorAgentPostal;
+        $this->localInstrument = 'CH03';
     }
 
     /**
@@ -60,7 +61,7 @@ class IS2CreditTransfer extends CreditTransfer
      */
     public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
     {
-        $root = $this->buildHeader($doc, $paymentInformation, 'CH03');
+        $root = $this->buildHeader($doc, $paymentInformation);
 
         $creditorAgent = $doc->createElement('CdtrAgt');
         $creditorAgentId = $doc->createElement('FinInstnId');
@@ -77,9 +78,9 @@ class IS2CreditTransfer extends CreditTransfer
         $creditorAccount->appendChild($this->creditorIBAN->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        if ($this->hasRemittanceInformation()) {
-            $root->appendChild($this->buildRemittanceInformation($doc));
-        }
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -46,6 +46,7 @@ class ISRCreditTransfer extends CreditTransfer
         $this->amount = $amount;
         $this->creditorAccount = $creditorAccount;
         $this->creditorReference = (string) $creditorReference;
+        $this->localInstrument = 'CH01';
     }
 
     /**
@@ -61,13 +62,15 @@ class ISRCreditTransfer extends CreditTransfer
      */
     public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
     {
-        $root = $this->buildHeader($doc, $paymentInformation, 'CH01');
+        $root = $this->buildHeader($doc, $paymentInformation);
 
         $creditorAccount = $doc->createElement('CdtrAcct');
         $creditorAccount->appendChild($this->creditorAccount->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        $root->appendChild($this->buildRemittanceInformation($doc));
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }
@@ -75,7 +78,7 @@ class ISRCreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    protected function buildRemittanceInformation(\DOMDocument $doc)
+    protected function appendRemittanceInformation(\DOMDocument $doc, \DOMElement $transaction)
     {
         $remittanceInformation = $doc->createElement('RmtInf');
 
@@ -87,14 +90,6 @@ class ISRCreditTransfer extends CreditTransfer
 
         $creditorReferenceInformation->appendChild($doc->createElement('Ref', $this->creditorReference));
 
-        return $remittanceInformation;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function hasRemittanceInformation()
-    {
-        return true;
+        $transaction->appendChild($remittanceInformation);
     }
 }

--- a/src/Z38/SwissPayment/TransactionInformation/PurposeCode.php
+++ b/src/Z38/SwissPayment/TransactionInformation/PurposeCode.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Z38\SwissPayment\TransactionInformation;
+
+use DOMDocument;
+use InvalidArgumentException;
+
+/**
+ * PurposeCode contains a purpose code from the External Code Sets
+ */
+class PurposeCode
+{
+    /**
+     * @var string
+     */
+    protected $code;
+
+    /**
+     * Constructor
+     *
+     * @param string $code
+     *
+     * @throws \InvalidArgumentException When the code is not valid
+     */
+    public function __construct($code)
+    {
+        $code = (string) $code;
+        if (!preg_match('/^[A-Z0-9]{4}$/', $code)) {
+            throw new InvalidArgumentException('The purpose code is not valid.');
+        }
+
+        $this->code = $code;
+    }
+
+    /**
+     * Returns a XML representation of this purpose
+     *
+     * @param \DOMDocument $doc
+     *
+     * @return \DOMElement The built DOM element
+     */
+    public function asDom(DOMDocument $doc)
+    {
+        return $doc->createElement('Cd', $this->code);
+    }
+}

--- a/src/Z38/SwissPayment/TransactionInformation/SEPACreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/SEPACreditTransfer.php
@@ -35,6 +35,7 @@ class SEPACreditTransfer extends CreditTransfer
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         $this->creditorIBAN = $creditorIBAN;
+        $this->serviceLevel = 'SEPA';
 
         if ($creditorAgentBIC !== null) {
             @trigger_error('Setting the creditor agent BIC of SEPA payments is deprecated. The execution of the payment will be based on the IBAN.', E_USER_DEPRECATED);
@@ -47,7 +48,7 @@ class SEPACreditTransfer extends CreditTransfer
      */
     public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
     {
-        $root = $this->buildHeader($doc, $paymentInformation, null, 'SEPA');
+        $root = $this->buildHeader($doc, $paymentInformation);
 
         if ($this->creditorAgentBIC !== null) {
             $creditorAgent = $doc->createElement('CdtrAgt');
@@ -61,9 +62,9 @@ class SEPACreditTransfer extends CreditTransfer
         $creditorAccount->appendChild($this->creditorIBAN->asDom($doc));
         $root->appendChild($creditorAccount);
 
-        if ($this->hasRemittanceInformation()) {
-            $root->appendChild($this->buildRemittanceInformation($doc));
-        }
+        $this->appendPurpose($doc, $root);
+
+        $this->appendRemittanceInformation($doc, $root);
 
         return $root;
     }

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/CategoryPurposeCodeTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/CategoryPurposeCodeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Z38\SwissPayment\Tests\PaymentInformation;
+
+use DOMDocument;
+use Z38\SwissPayment\PaymentInformation\CategoryPurposeCode;
+use Z38\SwissPayment\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\PaymentInformation\CategoryPurposeCode
+ */
+class CategoryPurposeCodeTest extends TestCase
+{
+    /**
+     * @dataProvider validSamples
+     * @covers ::__construct
+     */
+    public function testValid($code)
+    {
+        $this->assertInstanceOf('Z38\SwissPayment\PaymentInformation\CategoryPurposeCode', new CategoryPurposeCode($code));
+    }
+
+    public function validSamples()
+    {
+        return [
+            ['SALA'], // salary payment
+            ['PENS'], // pension payment
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSamples
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalid($code)
+    {
+        new CategoryPurposeCode($code);
+    }
+
+    public function invalidSamples()
+    {
+        return [
+            [''],
+            ['sala'],
+            ['SAL'],
+            [' SALA'],
+            ['B112'],
+        ];
+    }
+
+    /**
+     * @covers ::asDom
+     */
+    public function testAsDom()
+    {
+        $doc = new DOMDocument();
+        $iid = new CategoryPurposeCode('SALA');
+
+        $xml = $iid->asDom($doc);
+
+        $this->assertSame('Cd', $xml->nodeName);
+        $this->assertSame('SALA', $xml->textContent);
+    }
+}

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
@@ -2,10 +2,17 @@
 
 namespace Z38\SwissPayment\Tests\PaymentInformation;
 
+use DOMDocument;
+use DOMXPath;
 use Z38\SwissPayment\BIC;
 use Z38\SwissPayment\IBAN;
+use Z38\SwissPayment\Money;
+use Z38\SwissPayment\PaymentInformation\CategoryPurposeCode;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
+use Z38\SwissPayment\PostalAccount;
+use Z38\SwissPayment\StructuredPostalAddress;
 use Z38\SwissPayment\Tests\TestCase;
+use Z38\SwissPayment\TransactionInformation\IS1CreditTransfer;
 
 /**
  * @coversDefaultClass \Z38\SwissPayment\PaymentInformation\PaymentInformation
@@ -41,5 +48,44 @@ class PaymentInformationTest extends TestCase
         );
 
         $this->assertFalse($payment->hasPaymentTypeInformation());
+    }
+
+    /**
+     * @covers ::asDom
+     */
+    public function testInfersPaymentInformation()
+    {
+        $doc = new DOMDocument();
+        $payment = new PaymentInformation(
+            'id000',
+            'name',
+            new BIC('POFICHBEXXX'),
+            new IBAN('CH31 8123 9000 0012 4568 9')
+        );
+        $payment->setCategoryPurpose(new CategoryPurposeCode('SALA'));
+        $payment->addTransaction(new IS1CreditTransfer(
+            'instr-001',
+            'e2e-001',
+            new Money\CHF(10000), // CHF 100.00
+            'Fritz Bischof',
+            new StructuredPostalAddress('Dorfstrasse', '17', '9911', 'Musterwald'),
+            new PostalAccount('60-9-9')
+        ));
+        $payment->addTransaction(new IS1CreditTransfer(
+            'instr-002',
+            'e2e-002',
+            new Money\CHF(30000), // CHF 300.00
+            'Franziska Meier',
+            new StructuredPostalAddress('Altstadt', '1a', '4998', 'Muserhausen'),
+            new PostalAccount('80-151-4')
+        ));
+
+        $xml = $payment->asDom($doc);
+
+        $xpath = new DOMXPath($doc);
+        $this->assertNull($payment->getServiceLevel());
+        $this->assertNull($payment->getLocalInstrument());
+        $this->assertSame('CH02', $xpath->evaluate('string(./PmtTpInf/LclInstrm/Prtry)', $xml));
+        $this->assertSame(0.0, $xpath->evaluate('count(./CdtTrfTxInf/PmtTpInf/LclInstrm/Prtry)', $xml));
     }
 }

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/PurposeCodeTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/PurposeCodeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Z38\SwissPayment\Tests\TransactionInformation;
+
+use DOMDocument;
+use Z38\SwissPayment\Tests\TestCase;
+use Z38\SwissPayment\TransactionInformation\PurposeCode;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\TransactionInformation\PurposeCode
+ */
+class PurposeCodeTest extends TestCase
+{
+    /**
+     * @dataProvider validSamples
+     * @covers ::__construct
+     */
+    public function testValid($code)
+    {
+        $this->assertInstanceOf('Z38\SwissPayment\TransactionInformation\PurposeCode', new PurposeCode($code));
+    }
+
+    public function validSamples()
+    {
+        return [
+            ['SALA'], // salary payment
+            ['PENS'], // pension payment
+            ['DNTS'], // dental services
+            ['B112'], // US mutual fund trailer fee (12b-1) payment
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSamples
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalid($code)
+    {
+        new PurposeCode($code);
+    }
+
+    public function invalidSamples()
+    {
+        return [
+            [''],
+            ['sala'],
+            ['SAL'],
+            [' SALA'],
+        ];
+    }
+
+    /**
+     * @covers ::asDom
+     */
+    public function testAsDom()
+    {
+        $doc = new DOMDocument();
+        $iid = new PurposeCode('PHON');
+
+        $xml = $iid->asDom($doc);
+
+        $this->assertSame('Cd', $xml->nodeName);
+        $this->assertSame('PHON', $xml->textContent);
+    }
+}


### PR DESCRIPTION
This patch adds support for setting transaction purposes. As some institutions do not allow inheritance of `<PmtTpInf>` child elements, the `PaymentInformation` class tries to group transactions on B-level automatically.

Fixes: #14 