### PR TITLE
ISR improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .php_cs
 .php_cs.cache
-
 phpunit.xml
-
 composer.lock
 /vendor/
+/nbproject/

--- a/src/Z38/SwissPayment/ISRParticipant.php
+++ b/src/Z38/SwissPayment/ISRParticipant.php
@@ -31,6 +31,15 @@ class ISRParticipant implements AccountInterface
         } else {
             throw new InvalidArgumentException('ISR participant number is not properly formatted.');
         }
+
+        if (substr($this->number, 0, 2) !== '01'
+                && substr($this->number, 0, 2) !== '03') {
+            throw new InvalidArgumentException('ISR participant number must start by 01 [CHF] or 03 [EURO].');
+        }
+
+        if (PostalAccount::calculateCheckDigit(substr($this->number, 0, 8)) !== (int) substr($this->number, -1)) {
+            throw new InvalidArgumentException('Postal account number has an invalid check digit.');
+        }
     }
 
     /**

--- a/src/Z38/SwissPayment/PostalAccount.php
+++ b/src/Z38/SwissPayment/PostalAccount.php
@@ -73,7 +73,7 @@ class PostalAccount implements AccountInterface
         return $root;
     }
 
-    private static function calculateCheckDigit($number)
+    public static function calculateCheckDigit($number)
     {
         $lookup = [0, 9, 4, 6, 8, 2, 7, 1, 3, 5];
         $carry = 0;

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -8,6 +8,7 @@ use LogicException;
 use Z38\SwissPayment\ISRParticipant;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
+use Z38\SwissPayment\PostalAddressInterface;
 
 /**
  * ISRCreditTransfer contains all the information about a ISR (type 1) transaction.
@@ -64,6 +65,10 @@ class ISRCreditTransfer extends CreditTransfer
     {
         $root = $this->buildHeader($doc, $paymentInformation);
 
+        if (isset($this->creditorName) && isset($this->creditorAddress)) {
+            $root->appendChild($this->buildCreditor($doc));
+        }
+
         $creditorAccount = $doc->createElement('CdtrAcct');
         $creditorAccount->appendChild($this->creditorAccount->asDom($doc));
         $root->appendChild($creditorAccount);
@@ -91,5 +96,17 @@ class ISRCreditTransfer extends CreditTransfer
         $creditorReferenceInformation->appendChild($doc->createElement('Ref', $this->creditorReference));
 
         $transaction->appendChild($remittanceInformation);
+    }
+
+    /**
+     * Permit to set optional creditor details
+     *
+     * @param string                 $creditorName
+     * @param PostalAddressInterface $creditorAddress
+     */
+    public function setCreditorDetails($creditorName, PostalAddressInterface $creditorAddress)
+    {
+        $this->creditorName = $creditorName;
+        $this->creditorAddress = $creditorAddress;
     }
 }

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -121,7 +121,7 @@ class ISRCreditTransfer extends CreditTransfer
      *
      * @return int Recursive check digit.
      */
-    private static function modulo10(string $number)
+    private static function modulo10($number)
     {
         $moduloTable = [0, 9, 4, 6, 8, 2, 7, 1, 3, 5];
 

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -42,6 +42,10 @@ class ISRCreditTransfer extends CreditTransfer
             ));
         }
 
+        if (self::modulo10(substr($creditorReference, 0, -1)) != (int) substr($creditorReference, -1)) {
+            throw new InvalidArgumentException('Invalid ISR creditor reference.');
+        }
+
         $this->instructionId = (string) $instructionId;
         $this->endToEndId = (string) $endToEndId;
         $this->amount = $amount;
@@ -108,5 +112,24 @@ class ISRCreditTransfer extends CreditTransfer
     {
         $this->creditorName = $creditorName;
         $this->creditorAddress = $creditorAddress;
+    }
+
+    /**
+     * Creates Modulo10 recursive check digit
+     *
+     * @param string $number Number to create recursive check digit off.
+     *
+     * @return int Recursive check digit.
+     */
+    private static function modulo10(string $number)
+    {
+        $moduloTable = [0, 9, 4, 6, 8, 2, 7, 1, 3, 5];
+
+        $next = 0;
+        for ($i = 0; $i < strlen($number); $i++) {
+            $next = $moduloTable[($next + intval(substr($number, $i, 1))) % 10];
+        }
+
+        return (int) (10 - $next) % 10;
     }
 }

--- a/tests/Z38/SwissPayment/Tests/ISRParticipantTest.php
+++ b/tests/Z38/SwissPayment/Tests/ISRParticipantTest.php
@@ -40,15 +40,16 @@ class ISRParticipantTest extends TestCase
     public function validSamples()
     {
         return [
-            ['80-2-2'],
-            ['80-0470-3'],
-            ['123456789'],
+            ['01-394971-8'],
+            ['010059136'],
+            ['01-137-5'],
         ];
     }
 
     public function invalidSamples()
     {
         return [
+            ['01-394971-9'],
             ['01-7777777-2'],
             ['80-470-3-1'],
             ['12345678'],

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -129,7 +129,7 @@ class CustomerCreditTransferTest extends TestCase
             'instr-010',
             'e2e-010',
             new Money\CHF(20000), // CHF 200.00
-            new ISRParticipant('80-5928-4'),
+            new ISRParticipant('01-1439-8'),
             '210000000003139471430009017'
         );
 
@@ -146,7 +146,7 @@ class CustomerCreditTransferTest extends TestCase
             'instr-010',
             'e2e-010',
             new Money\CHF(20000), // CHF 200.00
-            new ISRParticipant('80-5928-4'),
+            new ISRParticipant('01-95106-8'),
             '210000000003139471430009017'
         );
         $transaction12->setCreditorDetails(

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -147,7 +147,7 @@ class CustomerCreditTransferTest extends TestCase
             'e2e-010',
             new Money\CHF(20000), // CHF 200.00
             new ISRParticipant('01-95106-8'),
-            '210000000003139471430009017'
+            '6019701803969733825'
         );
         $transaction12->setCreditorDetails(
             'Fritz Bischof',

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -142,6 +142,18 @@ class CustomerCreditTransferTest extends TestCase
             new PostalAccount('60-9-9')
         );
 
+        $transaction12 = new ISRCreditTransfer(
+            'instr-010',
+            'e2e-010',
+            new Money\CHF(20000), // CHF 200.00
+            new ISRParticipant('80-5928-4'),
+            '210000000003139471430009017'
+        );
+        $transaction12->setCreditorDetails(
+            'Fritz Bischof',
+            new StructuredPostalAddress('Dorfstrasse', '17', '9911', 'Musterwald')
+        );
+
         $payment = new PaymentInformation('payment-001', 'InnoMuster AG', new BIC('ZKBKCHZZ80A'), new IBAN('CH6600700110000204481'));
         $payment->addTransaction($transaction);
         $payment->addTransaction($transaction2);
@@ -159,6 +171,7 @@ class CustomerCreditTransferTest extends TestCase
 
         $payment4 = new PaymentInformation('payment-004', 'InnoMuster AG', new BIC('POFICHBEXXX'), new IBAN('CH6309000000250097798'));
         $payment4->addTransaction($transaction10);
+        $payment4->addTransaction($transaction12);
 
         $payment5 = new PaymentInformation('payment-005', 'InnoMuster AG', new BIC('POFICHBEXXX'), new IBAN('CH6309000000250097798'));
         $payment5->setCategoryPurpose(new CategoryPurposeCode('SALA'));
@@ -184,10 +197,10 @@ class CustomerCreditTransferTest extends TestCase
         $xpath->registerNamespace('pain001', self::NS_URI_ROOT.self::SCHEMA);
 
         $nbOfTxs = $xpath->evaluate('string(//pain001:GrpHdr/pain001:NbOfTxs)');
-        $this->assertEquals('11', $nbOfTxs);
+        $this->assertEquals('12', $nbOfTxs);
 
         $ctrlSum = $xpath->evaluate('string(//pain001:GrpHdr/pain001:CtrlSum)');
-        $this->assertEquals('4010.00', $ctrlSum);
+        $this->assertEquals('4210.00', $ctrlSum);
     }
 
     public function testSchemaValidation()

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
@@ -54,7 +54,7 @@ class ISRCreditTransferTest extends TestCase
             'id000',
             'name',
             new Money\CHF(100),
-            new ISRParticipant('10-2424-4'),
+            new ISRParticipant('01-25083-7'),
             '120000000000234478943216899'
         );
 

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
@@ -4,6 +4,7 @@ namespace Z38\SwissPayment\Tests\TransactionInformation;
 
 use Z38\SwissPayment\ISRParticipant;
 use Z38\SwissPayment\Money;
+use Z38\SwissPayment\StructuredPostalAddress;
 use Z38\SwissPayment\Tests\TestCase;
 use Z38\SwissPayment\TransactionInformation\ISRCreditTransfer;
 
@@ -42,5 +43,23 @@ class ISRCreditTransferTest extends TestCase
         );
 
         $transfer->setRemittanceInformation('not allowed');
+    }
+
+    /**
+     * @covers ::setCreditorDetails
+     */
+    public function testCreditorDetails()
+    {
+        $transfer = new ISRCreditTransfer(
+            'id000',
+            'name',
+            new Money\CHF(100),
+            new ISRParticipant('10-2424-4'),
+            '120000000000234478943216899'
+        );
+
+        $creditorName = 'name';
+        $creditorAddress = new StructuredPostalAddress('foo', '99', '9999', 'bar');
+        $transfer->setCreditorDetails($creditorName, $creditorAddress);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
@@ -29,6 +29,21 @@ class ISRCreditTransferTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidCreditorReference()
+    {
+        $transfer = new ISRCreditTransfer(
+            'id000',
+            'name',
+            new Money\CHF(100),
+            new ISRParticipant('01-25083-7'),
+            '120000000000234478943216891'
+        );
+    }
+
+    /**
      * @covers ::setRemittanceInformation
      * @expectedException \LogicException
      */
@@ -38,7 +53,7 @@ class ISRCreditTransferTest extends TestCase
             'id000',
             'name',
             new Money\CHF(100),
-            new ISRParticipant('10-2424-4'),
+            new ISRParticipant('01-25083-7'),
             '120000000000234478943216899'
         );
 


### PR DESCRIPTION
This PR add a feature and security checks for ISR :

- Permit to specify creditor details for ISRCreditTransfer : not mandatory as specify by `<Cdtr>` index 2.79 p38, but very useful to check payments in the e-banking portals.
- Add validation to check that ISR postal account number start by 01 (for CHF) or 03 (for Euro).
- Add creditor reference number integrity verification.
 