### PR TITLE
Validate and escape all inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ use Z38\SwissPayment\PostalAccount;
 use Z38\SwissPayment\StructuredPostalAddress;
 use Z38\SwissPayment\TransactionInformation\BankCreditTransfer;
 use Z38\SwissPayment\TransactionInformation\IS1CreditTransfer;
+use Z38\SwissPayment\UnstructuredPostalAddress;
 
 $transaction1 = new BankCreditTransfer(
     'instr-001',
@@ -43,7 +44,7 @@ $transaction2 = new IS1CreditTransfer(
     'e2e-002',
     new Money\CHF(30000), // CHF 300.00
     'Finanzverwaltung Stadt Musterhausen',
-    new StructuredPostalAddress('Altstadt', '1a', '4998', 'Muserhausen'),
+    UnstructuredPostalAddress::sanitize('Altstadt 1a', '4998 Musterhausen'),
     new PostalAccount('80-151-4')
 );
 

--- a/src/Z38/SwissPayment/FinancialInstitutionAddress.php
+++ b/src/Z38/SwissPayment/FinancialInstitutionAddress.php
@@ -22,10 +22,12 @@ class FinancialInstitutionAddress implements FinancialInstitutionInterface
      *
      * @param string $name Name of the FI
      * @param PostalAddressInterface Address of the FI
+     *
+     * @throws \InvalidArgumentException When the name is invalid.
      */
     public function __construct($name, PostalAddressInterface $address)
     {
-        $this->name = (string) $name;
+        $this->name = Text::assert($name, 70);
         $this->address = $address;
     }
 
@@ -35,7 +37,7 @@ class FinancialInstitutionAddress implements FinancialInstitutionInterface
     public function asDom(\DOMDocument $doc)
     {
         $xml = $doc->createElement('FinInstnId');
-        $xml->appendChild($doc->createElement('Nm', $this->name));
+        $xml->appendChild(Text::xml($doc, 'Nm', $this->name));
         $xml->appendChild($this->address->asDom($doc));
 
         return $xml;

--- a/src/Z38/SwissPayment/GeneralAccount.php
+++ b/src/Z38/SwissPayment/GeneralAccount.php
@@ -10,8 +10,6 @@ use InvalidArgumentException;
  */
 class GeneralAccount implements AccountInterface
 {
-    const MAX_LENGTH = 34;
-
     /**
      * @var string
      */
@@ -26,12 +24,7 @@ class GeneralAccount implements AccountInterface
      */
     public function __construct($id)
     {
-        $stringId = (string) $id;
-        if (strlen($stringId) > self::MAX_LENGTH) {
-            throw new InvalidArgumentException('The account identifcation is too long.');
-        }
-
-        $this->id = $stringId;
+        $this->id = Text::assert($id, 34);
     }
 
     /**
@@ -49,7 +42,7 @@ class GeneralAccount implements AccountInterface
     {
         $root = $doc->createElement('Id');
         $other = $doc->createElement('Othr');
-        $other->appendChild($doc->createElement('Id', $this->format()));
+        $other->appendChild(Text::xml($doc, 'Id', $this->format()));
         $root->appendChild($other);
 
         return $root;

--- a/src/Z38/SwissPayment/Message/AbstractMessage.php
+++ b/src/Z38/SwissPayment/Message/AbstractMessage.php
@@ -2,6 +2,8 @@
 
 namespace Z38\SwissPayment\Message;
 
+use Z38\SwissPayment\Text;
+
 /**
  * AbstractMessages eases message creation using DOM
  */
@@ -85,8 +87,8 @@ abstract class AbstractMessage implements MessageInterface
     {
         $root = $doc->createElement('CtctDtls');
 
-        $root->appendChild($doc->createElement('Nm', $this->getSoftwareName()));
-        $root->appendChild($doc->createElement('Othr', $this->getSoftwareVersion()));
+        $root->appendChild(Text::xml($doc, 'Nm', $this->getSoftwareName()));
+        $root->appendChild(Text::xml($doc, 'Othr', $this->getSoftwareVersion()));
 
         return $root;
     }

--- a/src/Z38/SwissPayment/StructuredPostalAddress.php
+++ b/src/Z38/SwissPayment/StructuredPostalAddress.php
@@ -8,12 +8,12 @@ namespace Z38\SwissPayment;
 class StructuredPostalAddress implements PostalAddressInterface
 {
     /**
-     * @var string
+     * @var string|null
      */
     protected $street;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $buildingNo;
 
@@ -40,14 +40,16 @@ class StructuredPostalAddress implements PostalAddressInterface
      * @param string      $postCode   Postal code
      * @param string      $town       Town name
      * @param string      $country    Country code (ISO 3166-1 alpha-2)
+     *
+     * @throws \InvalidArgumentException When the address contains invalid characters or is too long.
      */
     public function __construct($street, $buildingNo, $postCode, $town, $country = 'CH')
     {
-        $this->street = (string) $street;
-        $this->buildingNo = (string) $buildingNo;
-        $this->postCode = (string) $postCode;
-        $this->town = (string) $town;
-        $this->country = (string) $country;
+        $this->street = Text::assertOptional($street, 70);
+        $this->buildingNo = Text::assertOptional($buildingNo, 16);
+        $this->postCode = Text::assert($postCode, 16);
+        $this->town = Text::assert($town, 35);
+        $this->country = Text::assertCountryCode($country);
     }
 
     /**
@@ -57,15 +59,15 @@ class StructuredPostalAddress implements PostalAddressInterface
     {
         $root = $doc->createElement('PstlAdr');
 
-        if (strlen($this->street)) {
-            $root->appendChild($doc->createElement('StrtNm', $this->street));
+        if ($this->street !== null) {
+            $root->appendChild(Text::xml($doc, 'StrtNm', $this->street));
         }
-        if (strlen($this->buildingNo)) {
-            $root->appendChild($doc->createElement('BldgNb', $this->buildingNo));
+        if ($this->buildingNo !== null) {
+            $root->appendChild(Text::xml($doc, 'BldgNb', $this->buildingNo));
         }
-        $root->appendChild($doc->createElement('PstCd', $this->postCode));
-        $root->appendChild($doc->createElement('TwnNm', $this->town));
-        $root->appendChild($doc->createElement('Ctry', $this->country));
+        $root->appendChild(Text::xml($doc, 'PstCd', $this->postCode));
+        $root->appendChild(Text::xml($doc, 'TwnNm', $this->town));
+        $root->appendChild(Text::xml($doc, 'Ctry', $this->country));
 
         return $root;
     }

--- a/src/Z38/SwissPayment/StructuredPostalAddress.php
+++ b/src/Z38/SwissPayment/StructuredPostalAddress.php
@@ -53,6 +53,28 @@ class StructuredPostalAddress implements PostalAddressInterface
     }
 
     /**
+     * Creates a new instance after sanitizing all inputs
+     *
+     * @param string|null $street     Street name or null
+     * @param string|null $buildingNo Building number or null
+     * @param string      $postCode   Postal code
+     * @param string      $town       Town name
+     * @param string      $country    Country code (ISO 3166-1 alpha-2)
+     *
+     * @return StructuredPostalAddress
+     */
+    public static function sanitize($street, $buildingNo, $postCode, $town, $country = 'CH')
+    {
+        return new self(
+            Text::sanitizeOptional($street, 70),
+            Text::sanitizeOptional($buildingNo, 16),
+            Text::sanitize($postCode, 16),
+            Text::sanitize($town, 35),
+            $country
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function asDom(\DOMDocument $doc)

--- a/src/Z38/SwissPayment/Text.php
+++ b/src/Z38/SwissPayment/Text.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Z38\SwissPayment;
+
+use DOMDocument;
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+class Text
+{
+    const TEXT_CH = '/^[A-Za-z0-9 .,:\'\/()?+\-!"#%&*;<>÷=@_$£[\]{}\` ́~àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ]*$/u';
+    const TEXT_SWIFT = '/^[A-Za-z0-9 .,:\'\/()?+\-]*$/';
+
+    public static function assertOptional($input, $maxLength)
+    {
+        if ($input === null) {
+            return null;
+        }
+
+        return self::assert($input, $maxLength);
+    }
+
+    public static function assert($input, $maxLength)
+    {
+        return self::assertPattern($input, $maxLength, self::TEXT_CH);
+    }
+
+    public static function assertIdentifier($input)
+    {
+        $input = self::assertPattern($input, 35, self::TEXT_SWIFT);
+        if ($input[0] === '/' || strpos($input, '//') !== false) {
+            throw new InvalidArgumentException('The identifier contains unallowed slashes.');
+        }
+
+        return $input;
+    }
+
+    public static function assertCountryCode($input)
+    {
+        if (!preg_match('/^[A-Z]{2}$/', $input)) {
+            throw new InvalidArgumentException('The country code is invalid.');
+        }
+
+        return $input;
+    }
+
+    protected static function assertPattern($input, $maxLength, $pattern)
+    {
+        $length = function_exists('mb_strlen') ? mb_strlen($input, 'UTF-8') : strlen($input);
+        if (!is_string($input) || $length === 0 || $length > $maxLength) {
+            throw new InvalidArgumentException(sprintf('The string can not be empty or longer than %d characters.', $maxLength));
+        }
+        if (!preg_match($pattern, $input)) {
+            throw new InvalidArgumentException('The string contains invalid characters.');
+        }
+
+        return $input;
+    }
+
+    public static function xml(DOMDocument $doc, $tag, $content)
+    {
+        $element = $doc->createElement($tag);
+        $element->appendChild($doc->createTextNode($content));
+
+        return $element;
+    }
+}

--- a/src/Z38/SwissPayment/Text.php
+++ b/src/Z38/SwissPayment/Text.php
@@ -5,14 +5,47 @@ namespace Z38\SwissPayment;
 use DOMDocument;
 use InvalidArgumentException;
 
-/**
- * @internal
- */
 class Text
 {
-    const TEXT_CH = '/^[A-Za-z0-9 .,:\'\/()?+\-!"#%&*;<>÷=@_$£[\]{}\` ́~àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ]*$/u';
-    const TEXT_SWIFT = '/^[A-Za-z0-9 .,:\'\/()?+\-]*$/';
+    const TEXT_NON_CH = '/[^A-Za-z0-9 .,:\'\/()?+\-!"#%&*;<>÷=@_$£[\]{}\` ́~àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ]+/u';
+    const TEXT_NON_SWIFT = '/[^A-Za-z0-9 .,:\'\/()?+\-]+/';
 
+    /**
+     * Sanitizes and trims a string to conform to the Swiss character
+     * set.
+     *
+     * @param string|null $input
+     * @param int         $maxLength
+     *
+     * @return string The sanitized string
+     */
+    public static function sanitize($input, $maxLength)
+    {
+        $input = preg_replace('/\s+/', ' ', (string) $input);
+        $input = trim(preg_replace(self::TEXT_NON_CH, '', $input));
+
+        return function_exists('mb_substr') ? mb_substr($input, 0, $maxLength, 'UTF-8') : substr($input, 0, $maxLength);
+    }
+
+    /**
+     * Sanitizes and trims a string to conform to the Swiss character
+     * set.
+     *
+     * @param string|null $input
+     * @param int         $maxLength
+     *
+     * @return string|null The sanitized string or null if it is empty.
+     */
+    public static function sanitizeOptional($input, $maxLength)
+    {
+        $sanitized = self::sanitize($input, $maxLength);
+
+        return $sanitized !== '' ? $sanitized : null;
+    }
+
+    /**
+     * @internal
+     */
     public static function assertOptional($input, $maxLength)
     {
         if ($input === null) {
@@ -22,14 +55,20 @@ class Text
         return self::assert($input, $maxLength);
     }
 
+    /**
+     * @internal
+     */
     public static function assert($input, $maxLength)
     {
-        return self::assertPattern($input, $maxLength, self::TEXT_CH);
+        return self::assertNotPattern($input, $maxLength, self::TEXT_NON_CH);
     }
 
+    /**
+     * @internal
+     */
     public static function assertIdentifier($input)
     {
-        $input = self::assertPattern($input, 35, self::TEXT_SWIFT);
+        $input = self::assertNotPattern($input, 35, self::TEXT_NON_SWIFT);
         if ($input[0] === '/' || strpos($input, '//') !== false) {
             throw new InvalidArgumentException('The identifier contains unallowed slashes.');
         }
@@ -37,6 +76,9 @@ class Text
         return $input;
     }
 
+    /**
+     * @internal
+     */
     public static function assertCountryCode($input)
     {
         if (!preg_match('/^[A-Z]{2}$/', $input)) {
@@ -46,19 +88,22 @@ class Text
         return $input;
     }
 
-    protected static function assertPattern($input, $maxLength, $pattern)
+    protected static function assertNotPattern($input, $maxLength, $pattern)
     {
         $length = function_exists('mb_strlen') ? mb_strlen($input, 'UTF-8') : strlen($input);
         if (!is_string($input) || $length === 0 || $length > $maxLength) {
             throw new InvalidArgumentException(sprintf('The string can not be empty or longer than %d characters.', $maxLength));
         }
-        if (!preg_match($pattern, $input)) {
+        if (preg_match($pattern, $input)) {
             throw new InvalidArgumentException('The string contains invalid characters.');
         }
 
         return $input;
     }
 
+    /**
+     * @internal
+     */
     public static function xml(DOMDocument $doc, $tag, $content)
     {
         $element = $doc->createElement($tag);

--- a/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
@@ -9,6 +9,7 @@ use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
 use Z38\SwissPayment\PostalAddressInterface;
+use Z38\SwissPayment\Text;
 
 /**
  * IS2CreditTransfer contains all the information about a IS 2-stage (type 2.2) transaction.
@@ -51,7 +52,7 @@ class IS2CreditTransfer extends CreditTransfer
         parent::__construct($instructionId, $endToEndId, $amount, $creditorName, $creditorAddress);
 
         $this->creditorIBAN = $creditorIBAN;
-        $this->creditorAgentName = (string) $creditorAgentName;
+        $this->creditorAgentName = Text::assert($creditorAgentName, 70);
         $this->creditorAgentPostal = $creditorAgentPostal;
         $this->localInstrument = 'CH03';
     }
@@ -65,7 +66,7 @@ class IS2CreditTransfer extends CreditTransfer
 
         $creditorAgent = $doc->createElement('CdtrAgt');
         $creditorAgentId = $doc->createElement('FinInstnId');
-        $creditorAgentId->appendChild($doc->createElement('Nm', $this->creditorAgentName));
+        $creditorAgentId->appendChild(Text::xml($doc, 'Nm', $this->creditorAgentName));
         $creditorAgentIdOther = $doc->createElement('Othr');
         $creditorAgentIdOther->appendChild($doc->createElement('Id', $this->creditorAgentPostal->format()));
         $creditorAgentId->appendChild($creditorAgentIdOther);

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -10,6 +10,7 @@ use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
 use Z38\SwissPayment\PostalAddressInterface;
+use Z38\SwissPayment\Text;
 
 /**
  * ISRCreditTransfer contains all the information about a ISR (type 1) transaction.
@@ -43,15 +44,15 @@ class ISRCreditTransfer extends CreditTransfer
             ));
         }
 
-        if (!PostalAccount::validateCheckDigit($creditorReference)) {
-            throw new InvalidArgumentException('ISR creditor reference has an invalid check digit.');
+        if (!preg_match('/^[0-9]{1,27}$/', $creditorReference) || !PostalAccount::validateCheckDigit($creditorReference)) {
+            throw new InvalidArgumentException('ISR creditor reference is invalid.');
         }
 
-        $this->instructionId = (string) $instructionId;
-        $this->endToEndId = (string) $endToEndId;
+        $this->instructionId = Text::assertIdentifier($instructionId);
+        $this->endToEndId = Text::assertIdentifier($endToEndId);
         $this->amount = $amount;
         $this->creditorAccount = $creditorAccount;
-        $this->creditorReference = (string) $creditorReference;
+        $this->creditorReference = $creditorReference;
         $this->localInstrument = 'CH01';
     }
 
@@ -63,7 +64,7 @@ class ISRCreditTransfer extends CreditTransfer
      */
     public function setCreditorDetails($creditorName, PostalAddressInterface $creditorAddress)
     {
-        $this->creditorName = (string) $creditorName;
+        $this->creditorName = Text::assert($creditorName, 70);
         $this->creditorAddress = $creditorAddress;
     }
 

--- a/src/Z38/SwissPayment/UnstructuredPostalAddress.php
+++ b/src/Z38/SwissPayment/UnstructuredPostalAddress.php
@@ -39,6 +39,24 @@ class UnstructuredPostalAddress implements PostalAddressInterface
     }
 
     /**
+     * Creates a new instance after sanitizing all inputs
+     *
+     * @param string $addressLine1 Street name and house number
+     * @param string $addressLine2 Postcode and town
+     * @param string $country      Country code (ISO 3166-1 alpha-2)
+     *
+     * @return UnstructuredPostalAddress
+     */
+    public static function sanitize($addressLine1 = null, $addressLine2 = null, $country = 'CH')
+    {
+        return new self(
+            Text::sanitizeOptional($addressLine1, 70),
+            Text::sanitizeOptional($addressLine2, 70),
+            $country
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function asDom(\DOMDocument $doc)

--- a/src/Z38/SwissPayment/UnstructuredPostalAddress.php
+++ b/src/Z38/SwissPayment/UnstructuredPostalAddress.php
@@ -23,17 +23,19 @@ class UnstructuredPostalAddress implements PostalAddressInterface
      * @param string $addressLine1 Street name and house number
      * @param string $addressLine2 Postcode and town
      * @param string $country      Country code (ISO 3166-1 alpha-2)
+     *
+     * @throws \InvalidArgumentException When the address contains invalid characters or is too long.
      */
     public function __construct($addressLine1 = null, $addressLine2 = null, $country = 'CH')
     {
         $this->addressLines = [];
         if ($addressLine1 !== null) {
-            $this->addressLines[] = $addressLine1;
+            $this->addressLines[] = Text::assert($addressLine1, 70);
         }
         if ($addressLine2 !== null) {
-            $this->addressLines[] = $addressLine2;
+            $this->addressLines[] = Text::assert($addressLine2, 70);
         }
-        $this->country = (string) $country;
+        $this->country = Text::assertCountryCode($country);
     }
 
     /**
@@ -43,9 +45,9 @@ class UnstructuredPostalAddress implements PostalAddressInterface
     {
         $root = $doc->createElement('PstlAdr');
 
-        $root->appendChild($doc->createElement('Ctry', $this->country));
+        $root->appendChild(Text::xml($doc, 'Ctry', $this->country));
         foreach ($this->addressLines as $line) {
-            $root->appendChild($doc->createElement('AdrLine', $line));
+            $root->appendChild(Text::xml($doc, 'AdrLine', $line));
         }
 
         return $root;

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -149,7 +149,7 @@ class CustomerCreditTransferTest extends TestCase
             'instr-012',
             'e2e-012',
             new Money\CHF(50000), // CHF 500.00
-            'Fritz Bischof',
+            'Meier & Söhne AG',
             new StructuredPostalAddress('Dorfstrasse', '17', '9911', 'Musterwald'),
             new PostalAccount('60-9-9')
         );

--- a/tests/Z38/SwissPayment/Tests/StructuredPostalAddressTest.php
+++ b/tests/Z38/SwissPayment/Tests/StructuredPostalAddressTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Z38\SwissPayment\Tests;
+
+use Z38\SwissPayment\StructuredPostalAddress;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\StructuredPostalAddress
+ */
+class StructuredPostalAddressTest extends TestCase
+{
+    /**
+     * @covers ::sanitize
+     */
+    public function testSanitize()
+    {
+        $this->assertInstanceOf('Z38\SwissPayment\StructuredPostalAddress', StructuredPostalAddress::sanitize(
+            'Dorfstrasse',
+            '∅',
+            'Pfaffenschlag bei Waidhofen an der Thaya',
+            '3834',
+            'AT'
+        ));
+    }
+}

--- a/tests/Z38/SwissPayment/Tests/TextTest.php
+++ b/tests/Z38/SwissPayment/Tests/TextTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Z38\SwissPayment\Tests;
+
+use DOMDocument;
+use Z38\SwissPayment\Text;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\Text
+ */
+class TextTest extends TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAssertTooLong()
+    {
+        Text::assert('abcd', 3);
+    }
+
+    public function testAssertMaximumLength()
+    {
+        $this->assertSame('abcd', Text::assert('abcd', 4));
+    }
+
+    public function testAssertUnicode()
+    {
+        $this->assertSame('÷ß', Text::assert('÷ß', 2));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAssertInvalid()
+    {
+        Text::assert('°', 10);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAssertIdentiferBeginsWithSlash()
+    {
+        Text::assertIdentifier('/abc');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAssertIdentiferContainsDoubleSlash()
+    {
+        Text::assertIdentifier('ab//c');
+    }
+
+    public function testAssertIdentiferContainsSlash()
+    {
+        $this->assertSame('ab/c', Text::assertIdentifier('ab/c'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAssertCountryCodeUppercase()
+    {
+        Text::assertCountryCode('ch');
+    }
+
+    public function testXml()
+    {
+        $doc = new DOMDocument();
+
+        $element = Text::xml($doc, 'abc', '<>&');
+
+        $this->assertSame('<abc>&lt;&gt;&amp;</abc>', $doc->saveXML($element));
+    }
+}

--- a/tests/Z38/SwissPayment/Tests/TextTest.php
+++ b/tests/Z38/SwissPayment/Tests/TextTest.php
@@ -65,6 +65,30 @@ class TextTest extends TestCase
         Text::assertCountryCode('ch');
     }
 
+    /**
+     * @dataProvider sanitizeSamples
+     */
+    public function testSanitize($input, $expected)
+    {
+        $this->assertSame($expected, Text::sanitize($input, 3));
+    }
+
+    public function sanitizeSamples()
+    {
+        return [
+            ["\t  \t", ''],
+            ['°¬◆😀', ''],
+            ['  中文A B中文C  ', 'A B'],
+            ["ä \nÇ \n \nz", 'ä Ç'],
+            ['äääää', 'äää'],
+        ];
+    }
+
+    public function testSanitizeOptional()
+    {
+        $this->assertSame(null, Text::sanitizeOptional(" \t ° ° \t", 100));
+    }
+
     public function testXml()
     {
         $doc = new DOMDocument();

--- a/tests/Z38/SwissPayment/Tests/UnstructuredPostalAddressTest.php
+++ b/tests/Z38/SwissPayment/Tests/UnstructuredPostalAddressTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Z38\SwissPayment\Tests;
+
+use Z38\SwissPayment\UnstructuredPostalAddress;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\UnstructuredPostalAddress
+ */
+class UnstructuredPostalAddressTest extends TestCase
+{
+    /**
+     * @covers ::sanitize
+     */
+    public function testSanitize()
+    {
+        $this->assertInstanceOf('Z38\SwissPayment\UnstructuredPostalAddress', UnstructuredPostalAddress::sanitize(
+            "Dorf—Strasse 3\n\n",
+            "8000\tZürich"
+        ));
+    }
+}


### PR DESCRIPTION
This patch ensures all user inputs are either validated against a regexp (e.g. IBAN, ISR references) or are a subset of the officially supported character set.

In addition, the strings are escaped properly (where necessary). Previously, we relied on `DOMDocument::createElement($tag, $content)` which does no escaping at all.