### PR TITLE
Add option to generate unformatted XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .php_cs
 .php_cs.cache
-
 phpunit.xml
-
 composer.lock
 /vendor/
+/nbproject/*

--- a/src/Z38/SwissPayment/Message/AbstractMessage.php
+++ b/src/Z38/SwissPayment/Message/AbstractMessage.php
@@ -28,15 +28,17 @@ abstract class AbstractMessage implements MessageInterface
     /**
      * Builds a DOM document of the message
      *
+     * @param bool $formatOutput Nicely formats output with indentation and extra space.
+     *
      * @return \DOMDocument
      */
-    public function asDom()
+    public function asDom($formatOutput = true)
     {
         $schema = $this->getSchemaName();
         $ns = sprintf(self::SCHEMA_LOCATION, $schema);
 
         $doc = new \DOMDocument('1.0', 'UTF-8');
-        $doc->formatOutput = true;
+        $doc->formatOutput = $formatOutput;
         $root = $doc->createElement('Document');
         $root->setAttribute('xmlns', $ns);
         $root->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
@@ -50,9 +52,9 @@ abstract class AbstractMessage implements MessageInterface
     /**
      * {@inheritdoc}
      */
-    public function asXml()
+    public function asXml($formatOutput = true)
     {
-        return $this->asDom()->saveXML();
+        return $this->asDom($formatOutput)->saveXML();
     }
 
     /**

--- a/src/Z38/SwissPayment/Message/MessageInterface.php
+++ b/src/Z38/SwissPayment/Message/MessageInterface.php
@@ -10,7 +10,9 @@ interface MessageInterface
     /**
      * Returns a XML representation of the message
      *
+     * @param bool $formatOutput Nicely formats output with indentation and extra space.
+     *
      * @return string The XML source
      */
-    public function asXml();
+    public function asXml($formatOutput = true);
 }

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -189,7 +189,11 @@ class CustomerCreditTransferTest extends TestCase
 
     public function testGroupHeader()
     {
-        $xml = $this->buildMessage()->asXml();
+        $formattedXml = $this->buildMessage()->asXml();
+        $this->assertGreaterThan(5, count(preg_split('/\n|\r/',$formattedXml)));
+
+        $xml = $this->buildMessage()->asXml(false);
+        $this->assertLessThan(5, count(preg_split('/\n|\r/',$xml)));
 
         $doc = new \DOMDocument();
         $doc->loadXML($xml);


### PR DESCRIPTION
Except for debug purpose, pain.001 files should not contains formatted XML in order to take the least possible space on disk.