### PR TITLE
Fix StructuredPostalAddress regression

### DIFF
--- a/src/Z38/SwissPayment/StructuredPostalAddress.php
+++ b/src/Z38/SwissPayment/StructuredPostalAddress.php
@@ -57,10 +57,10 @@ class StructuredPostalAddress implements PostalAddressInterface
     {
         $root = $doc->createElement('PstlAdr');
 
-        if (!strlen($this->street)) {
+        if (strlen($this->street)) {
             $root->appendChild($doc->createElement('StrtNm', $this->street));
         }
-        if (!strlen($this->buildingNo)) {
+        if (strlen($this->buildingNo)) {
             $root->appendChild($doc->createElement('BldgNb', $this->buildingNo));
         }
         $root->appendChild($doc->createElement('PstCd', $this->postCode));


### PR DESCRIPTION
The test is inversed, so the street and the buillding number are not longer added to the XML!