### PR TITLE
Added Charge bearer for SEPA payment type

### DIFF
--- a/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
+++ b/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
@@ -257,6 +257,11 @@ class PaymentInformation
         $debtorAgent->appendChild($this->debtorAgent->asDom($doc));
         $root->appendChild($debtorAgent);
 
+        if($this->serviceLevel === "SEPA"){
+            $chargeBearer = $doc->createElement("ChrgBr", "SLEV");
+            $root->appendChild($chargeBearer);
+        }
+
         foreach ($this->transactions as $transaction) {
             if ($this->hasPaymentTypeInformation()) {
                 if ($transaction->getLocalInstrument() !== $localInstrument) {

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
@@ -52,6 +52,15 @@ class SEPAPaymentInformationTest extends TestCase
             new IBAN('DE89 3704 0044 0532 0130 00'),
             new BIC('COBADEFFXXX')
         ));
+        $payment->addTransaction(new SEPACreditTransfer(
+            'instr-002',
+            'e2e-002',
+            new Money\EUR(70000), // EUR 700.00
+            'Muster Immo AG',
+            new UnstructuredPostalAddress('Musterstraße 35', '80333 München', 'DE'),
+            new IBAN('DE89 3704 0044 0532 0130 00'),
+            new BIC('COBADEFFXXX')
+        ));
 
         $doc = new \DOMDocument();
         $dom = $payment->asDom($doc);
@@ -60,6 +69,9 @@ class SEPAPaymentInformationTest extends TestCase
         $xpath = new \DOMXPath($doc);
         $this->assertEquals('SEPA', $xpath->evaluate('string(/PmtInf/PmtTpInf/SvcLvl/Cd)'));
         $this->assertEquals(0, $xpath->evaluate('count(//CdtTrfTxInf/PmtTpInf)'));
+
+        $this->assertEquals(1, $xpath->evaluate('count(/PmtInf/ChrgBr)'));
+        $this->assertEquals('SLEV', $xpath->evaluate('string(/PmtInf/ChrgBr)'));
     }
 
     /**


### PR DESCRIPTION
According to UBS test platform, the charge bearer (ChrgBr B-Level 2.24 // C-Level 2.51) with value SLEV is requested for SEPA payments (Type 5). 

![capture d ecran 2018-04-17 a 15 47 46](https://user-images.githubusercontent.com/414630/38874140-b68a4a00-4257-11e8-98b1-5aa97f7baac1.png)

This element can be in B or C level, but cannot be on both.

I added it at the B-level as it is common for all the SEPA transactions. (item 2.24)

---

I will provide another PR later to add the ability to setup a charge bearer level for the other payment types. 

Thank you. 