### PR TITLE
Allow PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - 8.0
 
 before_script:
     - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SwissPayment Changelog
 
+## 0.8.0 (2021-xx-yy)
+
+  * Renamed Mixed to MixedMoney (reserved word as of PHP 7).
+  * Dropped support for PHP 5.6.
+
 ## 0.7.0 (2019-01-05)
 
   * Support creation of IIDs from Lichtenstein IBANs.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7"
+        "php": "^5.6 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^8"

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0 || ^8.0"
+        "php": "^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5 || ^8"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
+++ b/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
@@ -107,7 +107,7 @@ class CustomerCreditTransfer extends AbstractMessage
     protected function buildDom(\DOMDocument $doc)
     {
         $transactionCount = 0;
-        $transactionSum = new Money\Mixed(0);
+        $transactionSum = new Money\MixedMoney(0);
         foreach ($this->payments as $payment) {
             $transactionCount += $payment->getTransactionCount();
             $transactionSum = $transactionSum->plus($payment->getTransactionSum());

--- a/src/Z38/SwissPayment/Money/MixedMoney.php
+++ b/src/Z38/SwissPayment/Money/MixedMoney.php
@@ -5,7 +5,7 @@ namespace Z38\SwissPayment\Money;
 /**
  * Sum of money in mixed currencies
  */
-class Mixed extends Money
+class MixedMoney extends Money
 {
     /**
      * @var int

--- a/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
+++ b/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
@@ -117,11 +117,11 @@ class PaymentInformation
     /**
      * Gets the sum of transactions
      *
-     * @return Money\Mixed Sum of transactions
+     * @return Money\MixedMoney Sum of transactions
      */
     public function getTransactionSum()
     {
-        $sum = new Money\Mixed(0);
+        $sum = new Money\MixedMoney(0);
 
         foreach ($this->transactions as $transaction) {
             $sum = $sum->plus($transaction->getAmount());

--- a/tests/Z38/SwissPayment/Tests/BICTest.php
+++ b/tests/Z38/SwissPayment/Tests/BICTest.php
@@ -40,7 +40,7 @@ class BICTest extends TestCase
     public function testFormat($bic)
     {
         $instance = new BIC($bic);
-        $this->assertEquals($bic, $instance->format());
+        self::assertEquals($bic, $instance->format());
     }
 
     public function validSamples()
@@ -60,6 +60,6 @@ class BICTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $exception = true;
         }
-        $this->assertTrue($exception != $valid);
+        self::assertTrue($exception != $valid);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/GeneralAccountTest.php
+++ b/tests/Z38/SwissPayment/Tests/GeneralAccountTest.php
@@ -13,14 +13,15 @@ class GeneralAccountTest extends TestCase
     public function testValid()
     {
         $instance = new GeneralAccount('A-123-4567890-78');
+        self::assertInstanceOf(GeneralAccount::class, $instance);
     }
 
     /**
      * @covers \Z38\SwissPayment\GeneralAccount::__construct
-     * @expectedException InvalidArgumentException
      */
     public function testInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $instance = new GeneralAccount('0123456789012345678901234567890123456789');
     }
 
@@ -30,6 +31,6 @@ class GeneralAccountTest extends TestCase
     public function testFormat()
     {
         $instance = new GeneralAccount('  123-4567890-78 AA ');
-        $this->assertSame('  123-4567890-78 AA ', $instance->format());
+        self::assertSame('  123-4567890-78 AA ', $instance->format());
     }
 }

--- a/tests/Z38/SwissPayment/Tests/IBANTest.php
+++ b/tests/Z38/SwissPayment/Tests/IBANTest.php
@@ -40,7 +40,7 @@ class IBANTest extends TestCase
     public function testGetCountry($iban, $expectedCountry)
     {
         $instance = new IBAN($iban);
-        $this->assertEquals($expectedCountry, $instance->getCountry());
+        self::assertEquals($expectedCountry, $instance->getCountry());
     }
 
     /**
@@ -49,7 +49,7 @@ class IBANTest extends TestCase
     public function testFormat()
     {
         $iban = new IBAN('ch9300762011623852 957');
-        $this->assertEquals('CH93 0076 2011 6238 5295 7', $iban->format());
+        self::assertEquals('CH93 0076 2011 6238 5295 7', $iban->format());
     }
 
     /**
@@ -58,7 +58,7 @@ class IBANTest extends TestCase
     public function testNormalize()
     {
         $iban = new IBAN('fr14 2004 10100505 0001 3M02 606');
-        $this->assertEquals('FR1420041010050500013M02606', $iban->normalize());
+        self::assertEquals('FR1420041010050500013M02606', $iban->normalize());
     }
 
     /**
@@ -69,7 +69,7 @@ class IBANTest extends TestCase
     public function testToString($iban)
     {
         $instance = new IBAN($iban);
-        $this->assertEquals($instance->format(), (string) $instance);
+        self::assertEquals($instance->format(), (string) $instance);
     }
 
     public function samplesValid()
@@ -89,6 +89,6 @@ class IBANTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $exception = true;
         }
-        $this->assertTrue($exception != $valid);
+        self::assertTrue($exception != $valid);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/IIDTest.php
+++ b/tests/Z38/SwissPayment/Tests/IIDTest.php
@@ -18,7 +18,7 @@ class IIDTest extends TestCase
      */
     public function testValid($iid)
     {
-        $this->assertInstanceOf('Z38\SwissPayment\IID', new IID($iid));
+        self::assertInstanceOf('Z38\SwissPayment\IID', new IID($iid));
     }
 
     public function validSamples()
@@ -32,10 +32,10 @@ class IIDTest extends TestCase
     /**
      * @dataProvider invalidSamples
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidLength($iid)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new IID($iid);
     }
 
@@ -56,7 +56,7 @@ class IIDTest extends TestCase
     public function testFormat()
     {
         $instance = new IID('350');
-        $this->assertSame('00350', $instance->format());
+        self::assertSame('00350', $instance->format());
     }
 
     /**
@@ -66,7 +66,7 @@ class IIDTest extends TestCase
     public function testFromIBAN($iban, $iid)
     {
         $instance = IID::fromIBAN(new IBAN($iban));
-        $this->assertSame($iid, $instance->format());
+        self::assertSame($iid, $instance->format());
     }
 
     public function fromIBANSamples()
@@ -79,10 +79,10 @@ class IIDTest extends TestCase
 
     /**
      * @cover ::fromIban
-     * @expectedException \InvalidArgumentException
      */
     public function testFromIBANForeign()
     {
+        $this->expectException(\InvalidArgumentException::class);
         IID::fromIBAN(new IBAN('GB29 NWBK 6016 1331 9268 19'));
     }
 
@@ -97,6 +97,6 @@ class IIDTest extends TestCase
         $xml = $iid->asDom($doc);
 
         $xpath = new DOMXPath($doc);
-        $this->assertSame('9000', $xpath->evaluate('string(.//MmbId)', $xml));
+        self::assertSame('9000', $xpath->evaluate('string(.//MmbId)', $xml));
     }
 }

--- a/tests/Z38/SwissPayment/Tests/ISRParticipantTest.php
+++ b/tests/Z38/SwissPayment/Tests/ISRParticipantTest.php
@@ -15,16 +15,16 @@ class ISRParticipantTest extends TestCase
      */
     public function testValid($number)
     {
-        $this->assertInstanceOf('Z38\SwissPayment\ISRParticipant', new ISRParticipant($number));
+        self::assertInstanceOf('Z38\SwissPayment\ISRParticipant', new ISRParticipant($number));
     }
 
     /**
      * @dataProvider invalidSamples
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalid($number)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new ISRParticipant($number);
     }
 
@@ -34,7 +34,7 @@ class ISRParticipantTest extends TestCase
     public function testFormat()
     {
         $instance = new ISRParticipant('010001628');
-        $this->assertEquals('01-162-8', $instance->format());
+        self::assertEquals('01-162-8', $instance->format());
     }
 
     public function validSamples()

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -222,10 +222,10 @@ class CustomerCreditTransferTest extends TestCase
         $xpath->registerNamespace('pain001', self::SCHEMA);
 
         $nbOfTxs = $xpath->evaluate('string(//pain001:GrpHdr/pain001:NbOfTxs)');
-        $this->assertEquals('12', $nbOfTxs);
+        self::assertEquals('12', $nbOfTxs);
 
         $ctrlSum = $xpath->evaluate('string(//pain001:GrpHdr/pain001:CtrlSum)');
-        $this->assertEquals('4210.001', $ctrlSum);
+        self::assertEquals('4210.001', $ctrlSum);
     }
 
     public function testSchemaValidation()
@@ -241,7 +241,7 @@ class CustomerCreditTransferTest extends TestCase
         foreach (libxml_get_errors() as $error) {
             $this->fail($error->message);
         }
-        $this->assertTrue($valid);
+        self::assertTrue($valid);
         libxml_clear_errors();
         libxml_use_internal_errors(false);
     }
@@ -250,6 +250,6 @@ class CustomerCreditTransferTest extends TestCase
     {
         $message = $this->buildMessage();
 
-        $this->assertSame(5, $message->getPaymentCount());
+        self::assertSame(5, $message->getPaymentCount());
     }
 }

--- a/tests/Z38/SwissPayment/Tests/Money/MixedMoneyTest.php
+++ b/tests/Z38/SwissPayment/Tests/Money/MixedMoneyTest.php
@@ -8,28 +8,28 @@ use Z38\SwissPayment\Tests\TestCase;
 class MixedTest extends TestCase
 {
     /**
-     * @covers \Z38\SwissPayment\Money\Mixed::plus
+     * @covers \Z38\SwissPayment\Money\MixedMoney::plus
      */
     public function testPlus()
     {
-        $sum = new Money\Mixed(0);
+        $sum = new Money\MixedMoney(0);
         $sum = $sum->plus(new Money\CHF(2456));
         $sum = $sum->plus(new Money\CHF(1000));
         $sum = $sum->plus(new Money\JPY(1200));
 
-        $this->assertEquals('1234.56', $sum->format());
+        self::assertEquals('1234.56', $sum->format());
     }
 
     /**
-     * @covers \Z38\SwissPayment\Money\Mixed::minus
+     * @covers \Z38\SwissPayment\Money\MixedMoney::minus
      */
     public function testMinus()
     {
-        $sum = new Money\Mixed(100);
+        $sum = new Money\MixedMoney(100);
         $sum = $sum->minus(new Money\CHF(5000));
         $sum = $sum->minus(new Money\CHF(99));
         $sum = $sum->minus(new Money\JPY(300));
 
-        $this->assertEquals('-250.99', $sum->format());
+        self::assertEquals('-250.99', $sum->format());
     }
 }

--- a/tests/Z38/SwissPayment/Tests/Money/MoneyTest.php
+++ b/tests/Z38/SwissPayment/Tests/Money/MoneyTest.php
@@ -13,16 +13,16 @@ class MoneyTest extends TestCase
     public function testFormatWithDecimals()
     {
         $zero = new Money\CHF(0);
-        $this->assertEquals('0.00', $zero->format());
+        self::assertEquals('0.00', $zero->format());
 
         $money = new Money\CHF(1234567);
-        $this->assertEquals('12345.67', $money->format());
+        self::assertEquals('12345.67', $money->format());
 
         $money = new Money\CHF(-1234567);
-        $this->assertEquals('-12345.67', $money->format());
+        self::assertEquals('-12345.67', $money->format());
 
         $money = new Money\CHF(-2);
-        $this->assertEquals('-0.02', $money->format());
+        self::assertEquals('-0.02', $money->format());
     }
 
     /**
@@ -31,13 +31,13 @@ class MoneyTest extends TestCase
     public function testFormatWithoutDecimals()
     {
         $zero = new Money\JPY(0);
-        $this->assertEquals('0', $zero->format());
+        self::assertEquals('0', $zero->format());
 
         $money = new Money\JPY(123);
-        $this->assertEquals('123', $money->format());
+        self::assertEquals('123', $money->format());
 
         $money = new Money\JPY(-1123);
-        $this->assertEquals('-1123', $money->format());
+        self::assertEquals('-1123', $money->format());
     }
 
     /**
@@ -46,13 +46,13 @@ class MoneyTest extends TestCase
     public function testGetAmount()
     {
         $instance = new Money\CHF(345);
-        $this->assertEquals(345, $instance->getAmount());
+        self::assertEquals(345, $instance->getAmount());
 
         $instance = new Money\CHF(-345);
-        $this->assertEquals(-345, $instance->getAmount());
+        self::assertEquals(-345, $instance->getAmount());
 
         $instance = new Money\CHF(0);
-        $this->assertEquals(0, $instance->getAmount());
+        self::assertEquals(0, $instance->getAmount());
     }
 
     /**
@@ -62,14 +62,14 @@ class MoneyTest extends TestCase
     {
         $instance = new Money\CHF(-451);
 
-        $this->assertTrue($instance->equals($instance));
-        $this->assertTrue($instance->equals(new Money\CHF(-451)));
+        self::assertTrue($instance->equals($instance));
+        self::assertTrue($instance->equals(new Money\CHF(-451)));
 
-        $this->assertFalse($instance->equals(false));
-        $this->assertFalse($instance->equals(null));
-        $this->assertFalse($instance->equals(new \stdClass()));
-        $this->assertFalse($instance->equals(new Money\EUR(-451)));
-        $this->assertFalse($instance->equals(new Money\CHF(-41)));
+        self::assertFalse($instance->equals(false));
+        self::assertFalse($instance->equals(null));
+        self::assertFalse($instance->equals(new \stdClass()));
+        self::assertFalse($instance->equals(new Money\EUR(-451)));
+        self::assertFalse($instance->equals(new Money\CHF(-41)));
     }
 
     /**
@@ -80,38 +80,38 @@ class MoneyTest extends TestCase
      */
     public function testBinaryOperands($a, $b, $expectedSum, $expectedDiff, $expectedComparison)
     {
-        $this->assertTrue($expectedSum->equals($a->plus($b)));
-        $this->assertTrue($expectedDiff->equals($a->minus($b)));
-        $this->assertEquals($expectedComparison, $a->compareTo($b));
+        self::assertTrue($expectedSum->equals($a->plus($b)));
+        self::assertTrue($expectedDiff->equals($a->minus($b)));
+        self::assertEquals($expectedComparison, $a->compareTo($b));
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider invalidSamplePairs
      * @covers \Z38\SwissPayment\Money\Money::plus
      */
     public function testInvalidPlus($a, $b)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a->plus($b);
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider invalidSamplePairs
      * @covers \Z38\SwissPayment\Money\Money::minus
      */
     public function testInvalidMinus($a, $b)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a->minus($b);
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider invalidSamplePairs
      * @covers \Z38\SwissPayment\Money\Money::minus
      */
     public function testInvalidCompareTo($a, $b)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a->compareTo($b);
     }
 

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/CategoryPurposeCodeTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/CategoryPurposeCodeTest.php
@@ -17,7 +17,7 @@ class CategoryPurposeCodeTest extends TestCase
      */
     public function testValid($code)
     {
-        $this->assertInstanceOf('Z38\SwissPayment\PaymentInformation\CategoryPurposeCode', new CategoryPurposeCode($code));
+        self::assertInstanceOf('Z38\SwissPayment\PaymentInformation\CategoryPurposeCode', new CategoryPurposeCode($code));
     }
 
     public function validSamples()
@@ -31,10 +31,10 @@ class CategoryPurposeCodeTest extends TestCase
     /**
      * @dataProvider invalidSamples
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalid($code)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new CategoryPurposeCode($code);
     }
 
@@ -59,7 +59,7 @@ class CategoryPurposeCodeTest extends TestCase
 
         $xml = $iid->asDom($doc);
 
-        $this->assertSame('Cd', $xml->nodeName);
-        $this->assertSame('SALA', $xml->textContent);
+        self::assertSame('Cd', $xml->nodeName);
+        self::assertSame('SALA', $xml->textContent);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
@@ -22,10 +22,10 @@ class PaymentInformationTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidDebtorAgent()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $debtorAgent = $this->createMock(FinancialInstitutionInterface::class);
 
         $payment = new PaymentInformation(
@@ -48,7 +48,7 @@ class PaymentInformationTest extends TestCase
             new IBAN('CH31 8123 9000 0012 4568 9')
         );
 
-        $this->assertFalse($payment->hasPaymentTypeInformation());
+        self::assertFalse($payment->hasPaymentTypeInformation());
     }
 
     /**
@@ -84,9 +84,9 @@ class PaymentInformationTest extends TestCase
         $xml = $payment->asDom($doc);
 
         $xpath = new DOMXPath($doc);
-        $this->assertNull($payment->getServiceLevel());
-        $this->assertNull($payment->getLocalInstrument());
-        $this->assertSame('CH02', $xpath->evaluate('string(./PmtTpInf/LclInstrm/Prtry)', $xml));
-        $this->assertSame(0.0, $xpath->evaluate('count(./CdtTrfTxInf/PmtTpInf/LclInstrm/Prtry)', $xml));
+        self::assertNull($payment->getServiceLevel());
+        self::assertNull($payment->getLocalInstrument());
+        self::assertSame('CH02', $xpath->evaluate('string(./PmtTpInf/LclInstrm/Prtry)', $xml));
+        self::assertSame(0.0, $xpath->evaluate('count(./CdtTrfTxInf/PmtTpInf/LclInstrm/Prtry)', $xml));
     }
 }

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
@@ -29,7 +29,7 @@ class SEPAPaymentInformationTest extends TestCase
             new IBAN('CH31 8123 9000 0012 4568 9')
         );
 
-        $this->assertTrue($payment->hasPaymentTypeInformation());
+        self::assertTrue($payment->hasPaymentTypeInformation());
     }
 
     /**
@@ -58,17 +58,17 @@ class SEPAPaymentInformationTest extends TestCase
         $doc->appendChild($dom);
 
         $xpath = new \DOMXPath($doc);
-        $this->assertEquals('SEPA', $xpath->evaluate('string(/PmtInf/PmtTpInf/SvcLvl/Cd)'));
-        $this->assertEquals(0, $xpath->evaluate('count(//CdtTrfTxInf/PmtTpInf)'));
+        self::assertEquals('SEPA', $xpath->evaluate('string(/PmtInf/PmtTpInf/SvcLvl/Cd)'));
+        self::assertEquals(0, $xpath->evaluate('count(//CdtTrfTxInf/PmtTpInf)'));
     }
 
     /**
      * @covers ::asDom
-     * @expectedException \LogicException
-     * @expectedExceptionMessage You can not set the service level on B- and C-level.
      */
     public function testAsDomWithNonSEPATransaction()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You can not set the service level on B- and C-level.');
         $payment = new SEPAPaymentInformation(
             'id000',
             'name',

--- a/tests/Z38/SwissPayment/Tests/PostalAccountTest.php
+++ b/tests/Z38/SwissPayment/Tests/PostalAccountTest.php
@@ -2,7 +2,6 @@
 
 namespace Z38\SwissPayment\Tests;
 
-use InvalidArgumentException;
 use Z38\SwissPayment\PostalAccount;
 
 /**
@@ -16,7 +15,7 @@ class PostalAccountTest extends TestCase
      */
     public function testValid($postalAccount)
     {
-        $this->assertInstanceOf('Z38\SwissPayment\PostalAccount', new PostalAccount($postalAccount));
+        self::assertInstanceOf('Z38\SwissPayment\PostalAccount', new PostalAccount($postalAccount));
     }
 
     public function validSamples()
@@ -35,11 +34,11 @@ class PostalAccountTest extends TestCase
     /**
      * @dataProvider invalidFormatSamples
      * @covers ::__construct
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Postal account number is not properly formatted.
      */
     public function testInvalidFormat($postalAccount)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Postal account number is not properly formatted.');
         new PostalAccount($postalAccount);
     }
 
@@ -57,11 +56,11 @@ class PostalAccountTest extends TestCase
     /**
      * @dataProvider invalidCheckDigitSamples
      * @covers ::__construct
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Postal account number has an invalid check digit.
      */
     public function testInvalidCheckDigit($postalAccount)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Postal account number has an invalid check digit.');
         new PostalAccount($postalAccount);
     }
 
@@ -81,6 +80,6 @@ class PostalAccountTest extends TestCase
     public function testFormat($postalAccount)
     {
         $instance = new PostalAccount($postalAccount);
-        $this->assertEquals($postalAccount, $instance->format());
+        self::assertEquals($postalAccount, $instance->format());
     }
 }

--- a/tests/Z38/SwissPayment/Tests/StructuredPostalAddressTest.php
+++ b/tests/Z38/SwissPayment/Tests/StructuredPostalAddressTest.php
@@ -14,7 +14,7 @@ class StructuredPostalAddressTest extends TestCase
      */
     public function testSanitize()
     {
-        $this->assertInstanceOf('Z38\SwissPayment\StructuredPostalAddress', StructuredPostalAddress::sanitize(
+        self::assertInstanceOf('Z38\SwissPayment\StructuredPostalAddress', StructuredPostalAddress::sanitize(
             'Dorfstrasse',
             '∅',
             'Pfaffenschlag bei Waidhofen an der Thaya',

--- a/tests/Z38/SwissPayment/Tests/TextTest.php
+++ b/tests/Z38/SwissPayment/Tests/TextTest.php
@@ -10,58 +10,48 @@ use Z38\SwissPayment\Text;
  */
 class TextTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAssertTooLong()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Text::assert('abcd', 3);
     }
 
     public function testAssertMaximumLength()
     {
-        $this->assertSame('abcd', Text::assert('abcd', 4));
+        self::assertSame('abcd', Text::assert('abcd', 4));
     }
 
     public function testAssertUnicode()
     {
-        $this->assertSame('÷ß', Text::assert('÷ß', 2));
+        self::assertSame('÷ß', Text::assert('÷ß', 2));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAssertInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Text::assert('°', 10);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAssertIdentiferBeginsWithSlash()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Text::assertIdentifier('/abc');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAssertIdentiferContainsDoubleSlash()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Text::assertIdentifier('ab//c');
     }
 
     public function testAssertIdentiferContainsSlash()
     {
-        $this->assertSame('ab/c', Text::assertIdentifier('ab/c'));
+        self::assertSame('ab/c', Text::assertIdentifier('ab/c'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAssertCountryCodeUppercase()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Text::assertCountryCode('ch');
     }
 
@@ -70,7 +60,7 @@ class TextTest extends TestCase
      */
     public function testSanitize($input, $expected)
     {
-        $this->assertSame($expected, Text::sanitize($input, 3));
+        self::assertSame($expected, Text::sanitize($input, 3));
     }
 
     public function sanitizeSamples()
@@ -86,7 +76,7 @@ class TextTest extends TestCase
 
     public function testSanitizeOptional()
     {
-        $this->assertSame(null, Text::sanitizeOptional(" \t ° ° \t", 100));
+        self::assertSame(null, Text::sanitizeOptional(" \t ° ° \t", 100));
     }
 
     public function testXml()
@@ -95,6 +85,6 @@ class TextTest extends TestCase
 
         $element = Text::xml($doc, 'abc', '<>&');
 
-        $this->assertSame('<abc>&lt;&gt;&amp;</abc>', $doc->saveXML($element));
+        self::assertSame('<abc>&lt;&gt;&amp;</abc>', $doc->saveXML($element));
     }
 }

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/BankCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/BankCreditTransferTest.php
@@ -17,10 +17,11 @@ class BankCreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreditorAgent()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $creditorAgent = $this->createMock(FinancialInstitutionInterface::class);
 
         $transfer = new BankCreditTransfer(
@@ -36,10 +37,11 @@ class BankCreditTransferTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAmount()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $transfer = new BankCreditTransfer(
             'id000',
             'name',

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/ForeignCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/ForeignCreditTransferTest.php
@@ -16,10 +16,10 @@ class ForeignCreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreditorAgent()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $creditorAgent = $this->createMock(FinancialInstitutionInterface::class);
 
         $transfer = new ForeignCreditTransfer(

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/IS1CreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/IS1CreditTransferTest.php
@@ -15,10 +15,10 @@ class IS1CreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAmount()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $transfer = new IS1CreditTransfer(
             'id000',
             'name',

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/IS2CreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/IS2CreditTransferTest.php
@@ -16,10 +16,10 @@ class IS2CreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAmount()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $transfer = new IS2CreditTransfer(
             'id000',
             'name',

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/ISRCreditTransferTest.php
@@ -15,10 +15,10 @@ class ISRCreditTransferTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAmount()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $transfer = new ISRCreditTransfer(
             'id000',
             'name',
@@ -30,10 +30,10 @@ class ISRCreditTransferTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreditorReference()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $transfer = new ISRCreditTransfer(
             'id000',
             'name',
@@ -45,10 +45,11 @@ class ISRCreditTransferTest extends TestCase
 
     /**
      * @covers ::setRemittanceInformation
-     * @expectedException \LogicException
      */
     public function testSetRemittanceInformation()
     {
+        $this->expectException(\LogicException::class);
+
         $transfer = new ISRCreditTransfer(
             'id000',
             'name',
@@ -76,5 +77,7 @@ class ISRCreditTransferTest extends TestCase
         $creditorName = 'name';
         $creditorAddress = new StructuredPostalAddress('foo', '99', '9999', 'bar');
         $transfer->setCreditorDetails($creditorName, $creditorAddress);
+
+        self::assertInstanceOf(ISRCreditTransfer::class, $transfer);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/TransactionInformation/PurposeCodeTest.php
+++ b/tests/Z38/SwissPayment/Tests/TransactionInformation/PurposeCodeTest.php
@@ -17,7 +17,7 @@ class PurposeCodeTest extends TestCase
      */
     public function testValid($code)
     {
-        $this->assertInstanceOf('Z38\SwissPayment\TransactionInformation\PurposeCode', new PurposeCode($code));
+        self::assertInstanceOf('Z38\SwissPayment\TransactionInformation\PurposeCode', new PurposeCode($code));
     }
 
     public function validSamples()
@@ -33,10 +33,10 @@ class PurposeCodeTest extends TestCase
     /**
      * @dataProvider invalidSamples
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalid($code)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new PurposeCode($code);
     }
 
@@ -60,7 +60,7 @@ class PurposeCodeTest extends TestCase
 
         $xml = $iid->asDom($doc);
 
-        $this->assertSame('Cd', $xml->nodeName);
-        $this->assertSame('PHON', $xml->textContent);
+        self::assertSame('Cd', $xml->nodeName);
+        self::assertSame('PHON', $xml->textContent);
     }
 }

--- a/tests/Z38/SwissPayment/Tests/UnstructuredPostalAddressTest.php
+++ b/tests/Z38/SwissPayment/Tests/UnstructuredPostalAddressTest.php
@@ -14,7 +14,7 @@ class UnstructuredPostalAddressTest extends TestCase
      */
     public function testSanitize()
     {
-        $this->assertInstanceOf('Z38\SwissPayment\UnstructuredPostalAddress', UnstructuredPostalAddress::sanitize(
+        self::assertInstanceOf('Z38\SwissPayment\UnstructuredPostalAddress', UnstructuredPostalAddress::sanitize(
             "Dorf—Strasse 3\n\n",
             "8000\tZürich"
         ));


### PR DESCRIPTION
- Bumped PHP version to 8.0
- Dropped PHP 5.6 support
- Bumped PHPUnit version
- Renamed Mixed to MixedMoney because mixed is a reserved word as of PHP 7